### PR TITLE
Use true random source

### DIFF
--- a/app/ticketing/models.py
+++ b/app/ticketing/models.py
@@ -1,4 +1,4 @@
-import random
+import secrets
 from datetime import date
 
 from django.contrib.auth.models import AbstractUser
@@ -8,7 +8,8 @@ from .enums import UserAuthType
 
 
 def gen_ticket_id():
-    return f"GSB{''.join(random.choices('ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789', k=8))}"
+    # 32 possibilities * 10 characters = 50 bits of entropy
+    return "GSB" + ''.join(secrets.choice('ABCDEFGHJKLMNPQRSTUVWXYZ23456789') for _ in range(10))
 
 
 class PaymentMethodManager(models.Manager):


### PR DESCRIPTION
In anticipation of an upcoming audit, I ran a code lint to catch common security related errors:

## >> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
```
   Location: ./app/ticketing/models.py:11:25
10	def gen_ticket_id():
11	    return f"GSB{''.join(random.choices('ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789', k=8))}"
12	

```

If an attacker can determine the current state of the random generator, then they could theoretically be able to guess the next value of `gen_ticket_id`. This is bad if we use ticket id on QR codes for example.

Practically speaking, this was never a security vulnerability. An attacker needs to have access to 400 ticket IDs to get the 19968 bits of entropy required to predict `random`. Even then, the attacker would have to be incredibly competent in order to reverse engineer the GSB ticketing platform, `random.choices` and then the Mersenne-Twister algorithm.
